### PR TITLE
feat: refine auction filtering and fix in-memory pagination

### DIFF
--- a/src/main/java/me/vrishab/auction/auction/AuctionController.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionController.java
@@ -68,7 +68,7 @@ public class AuctionController {
     public Result findAllAuctions(
             @ModelAttribute
             @Valid PageRequestParams pageParams,
-            @RequestParam(defaultValue = "false") boolean active) {
+            @RequestParam(required = false) Boolean active) {
         Page<Auction> auctionPage = this.auctionService.findAll(pageParams, active);
 
         List<AuctionDTO> dtos = auctionPage.getContent().stream().map(

--- a/src/main/java/me/vrishab/auction/auction/AuctionRepository.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionRepository.java
@@ -1,9 +1,6 @@
 package me.vrishab.auction.auction;
 
 import me.vrishab.auction.user.model.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -16,8 +13,4 @@ public interface AuctionRepository extends JpaRepository<Auction, UUID>, JpaSpec
     List<Auction> findByUser(User user);
 
     void deleteByUser(User user);
-
-    @Override
-    @EntityGraph(attributePaths = {"items"})
-    Page<Auction> findAll(Pageable pageable);
 }

--- a/src/main/java/me/vrishab/auction/auction/AuctionService.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionService.java
@@ -65,13 +65,17 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Auction> findAll(PageRequestParams pageSettings, boolean active) {
+    public Page<Auction> findAll(PageRequestParams pageSettings, Boolean active) {
         Pageable pageable = Pageable.unpaged();
         if (pageSettings != null && pageSettings.isValid())
             pageable = pageSettings.createPageRequest();
 
-        if (active) {
-            return this.auctionRepo.findAll(AuctionSpecification.isActive(), pageable);
+        if (active != null) {
+            if (active) {
+                return this.auctionRepo.findAll(AuctionSpecification.isActive(), pageable);
+            } else {
+                return this.auctionRepo.findAll(AuctionSpecification.isInactive(), pageable);
+            }
         }
 
         return this.auctionRepo.findAll(pageable);

--- a/src/main/java/me/vrishab/auction/auction/AuctionSpecification.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionSpecification.java
@@ -16,4 +16,14 @@ public class AuctionSpecification {
         };
     }
 
+    public static Specification<Auction> isInactive() {
+        return (root, query, criteriaBuilder) -> {
+            Instant now = Instant.now();
+            return criteriaBuilder.or(
+                    criteriaBuilder.greaterThan(root.get("startTime"), now),
+                    criteriaBuilder.lessThan(root.get("endTime"), now)
+            );
+        };
+    }
+
 }

--- a/src/test/java/me/vrishab/auction/auction/AuctionControllerTest.java
+++ b/src/test/java/me/vrishab/auction/auction/AuctionControllerTest.java
@@ -108,7 +108,7 @@ class AuctionControllerTest {
     void testFindAllAuctionsSuccess() throws Exception {
 
         // Given
-        given(auctionService.findAll(new PageRequestParams(null, null), false))
+        given(auctionService.findAll(new PageRequestParams(null, null), null))
                 .willReturn(new PageImpl<>(this.auctions));
 
         // Then and When

--- a/src/test/java/me/vrishab/auction/auction/AuctionServiceTest.java
+++ b/src/test/java/me/vrishab/auction/auction/AuctionServiceTest.java
@@ -154,7 +154,7 @@ class AuctionServiceTest {
                 );
 
         // When
-        Page<Auction> returnedAuctionPage = auctionService.findAll(new PageRequestParams(null, null), false);
+        Page<Auction> returnedAuctionPage = auctionService.findAll(new PageRequestParams(null, null), null);
 
         // Then
         assertThat(returnedAuctionPage.getContent()).hasSize(9);
@@ -174,7 +174,7 @@ class AuctionServiceTest {
                 ));
 
         // When
-        Page<Auction> returnedAuctionPage = auctionService.findAll(new PageRequestParams(page, size), false);
+        Page<Auction> returnedAuctionPage = auctionService.findAll(new PageRequestParams(page, size), null);
 
         // Then
 

--- a/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
+++ b/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
@@ -112,7 +112,7 @@ public class DashboardFeaturesIntegrationTest {
     @Test
     @DisplayName("Verify active auctions filtering")
     void testActiveAuctionsFiltering() throws Exception {
-        // Find all (active=false by default)
+        // Find all (active not provided)
         mockMvc.perform(get(baseUrl + "/auctions")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -127,6 +127,15 @@ public class DashboardFeaturesIntegrationTest {
                 .andExpect(jsonPath("$.flag").value(true))
                 .andExpect(jsonPath("$.data.content", hasSize(1)))
                 .andExpect(jsonPath("$.data.content[0].name").value("Active Auction"));
+
+        // Find inactive only
+        mockMvc.perform(get(baseUrl + "/auctions")
+                        .param("active", "false")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.data.content", hasSize(2)))
+                .andExpect(jsonPath("$.data.content[*].name", containsInAnyOrder("Future Auction", "Past Auction")));
     }
 
     @Test


### PR DESCRIPTION
Refines the 'active' query parameter logic and resolves Hibernate performance warnings.
- Updated AuctionController and AuctionService to support active, inactive, and all auction filtering.
- Added AuctionSpecification.isInactive() for explicit inactive filtering.
- Fixed HHH90003004 warning by removing @EntityGraph from AuctionRepository.findAll.
- Updated unit and integration tests to verify refined logic and maintain coverage.