### PR TITLE
fix: resolve JPA transaction error when adding items to wishlist

### DIFF
--- a/src/main/java/me/vrishab/auction/item/Item.java
+++ b/src/main/java/me/vrishab/auction/item/Item.java
@@ -71,7 +71,7 @@ public class Item {
     private User buyer;
 
     @Version
-    private Long version;
+    private Long version = 0L;
 
     public String getBuyerEmail() {
         if (buyer == null) return null;

--- a/src/main/java/me/vrishab/auction/user/UserService.java
+++ b/src/main/java/me/vrishab/auction/user/UserService.java
@@ -114,11 +114,9 @@ public class UserService implements UserDetailsService {
         User user = getUser(userId);
 
         UUID itemUUID = UUID.fromString(itemId);
-        UUID userUUID = UUID.fromString(userId);
         Item item = this.itemRepo.findById(itemUUID).orElseThrow(() -> new ItemNotFoundByIdException(itemUUID));
         user.addFavouriteItem(item);
 
-        this.userRepo.addItemToWishlist(userUUID, itemUUID);
         return user.getWishlist().stream().toList();
     }
 
@@ -126,11 +124,8 @@ public class UserService implements UserDetailsService {
         User user = getUser(userId);
 
         UUID itemUUID = UUID.fromString(itemId);
-        UUID userUUID = UUID.fromString(userId);
         Item item = this.itemRepo.findById(itemUUID).orElseThrow(() -> new ItemNotFoundByIdException(itemUUID));
         user.removeFavouriteItem(item);
-
-        this.userRepo.removeItemFromWishlist(userUUID, itemUUID);
 
         return user.getWishlist().stream().toList();
     }


### PR DESCRIPTION
Fixes a NullPointerException in Hibernate versioning and simplifies wishlist service logic.
- Initialized @Version field in Item entity to 0L.
- Removed redundant repository calls in UserService.addItem/removeItem as JPA handles bidirectional relationship updates automatically within transactions.