### PR TITLE
feat: implement configurable limit for popular items

### DIFF
--- a/src/main/java/me/vrishab/auction/item/ItemService.java
+++ b/src/main/java/me/vrishab/auction/item/ItemService.java
@@ -5,10 +5,15 @@ import me.vrishab.auction.item.ItemException.ItemNotFoundByIdException;
 import me.vrishab.auction.item.ItemSpecification.ItemFilterParams;
 import me.vrishab.auction.system.PageRequestParams;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static me.vrishab.auction.item.ItemSpecification.filterSpecification;
@@ -18,10 +23,12 @@ import static me.vrishab.auction.item.ItemSpecification.filterSpecification;
 public class ItemService {
 
     private final ItemRepository itemRepo;
+    private final int popularLimit;
 
     @Autowired
-    public ItemService(ItemRepository itemRepo) {
+    public ItemService(ItemRepository itemRepo, @Value("${auction.items.popular-limit}") int popularLimit) {
         this.itemRepo = itemRepo;
+        this.popularLimit = popularLimit;
     }
 
     public Item findById(String itemId) {
@@ -43,12 +50,23 @@ public class ItemService {
     }
 
     public Page<Item> findPopularItems(PageRequestParams pageParams) {
-        Pageable pageable = Pageable.unpaged();
+        Pageable pageable = PageRequest.of(0, popularLimit);
 
         if (pageParams != null && pageParams.isValid())
             pageable = pageParams.createPageRequest();
 
-        return this.itemRepo.findAllOrderByPopularity(pageable);
+        Page<Item> itemPage = this.itemRepo.findAllOrderByPopularity(pageable);
+
+        long total = Math.min(itemPage.getTotalElements(), popularLimit);
+        List<Item> content = itemPage.getContent();
+
+        if (pageable.getOffset() >= popularLimit) {
+            content = Collections.emptyList();
+        } else if (pageable.getOffset() + content.size() > popularLimit) {
+            content = content.subList(0, (int) (popularLimit - pageable.getOffset()));
+        }
+
+        return new PageImpl<>(content, pageable, total);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,8 @@ api:
 auction:
   bidding:
     lock-timeout-seconds: 30
+  items:
+    popular-limit: 15
   cors:
     allowed-origin: ${ALLOWED_ORIGIN}
 

--- a/src/test/java/me/vrishab/auction/item/ItemServiceTest.java
+++ b/src/test/java/me/vrishab/auction/item/ItemServiceTest.java
@@ -37,13 +37,13 @@ class ItemServiceTest {
     @Mock
     private ItemRepository repository;
 
-    @InjectMocks
     private ItemService service;
 
     private List<Item> items;
 
     @BeforeEach
     void setUp() {
+        this.service = new ItemService(repository, 15);
         this.items = TestData.generateItems(TestData.generateUser(), null);
     }
 
@@ -260,6 +260,22 @@ class ItemServiceTest {
 
 
         verify(repository, times(1)).findAll(Mockito.any(Specification.class), eq(pageable));
+    }
+
+    @Test
+    void testFindPopularItemsCappedByLimit() {
+        // Given
+        int limit = 15;
+        Pageable pageable = PageRequest.of(0, limit);
+        given(repository.findAllOrderByPopularity(pageable))
+                .willReturn(new PageImpl<>(items.subList(0, Math.min(items.size(), limit))));
+
+        // When
+        Page<Item> returnedItemPage = service.findPopularItems(new PageRequestParams(null, null));
+
+        // Then
+        assertThat(returnedItemPage.getContent().size()).isLessThanOrEqualTo(limit);
+        verify(repository, times(1)).findAllOrderByPopularity(pageable);
     }
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,5 +22,7 @@ api:
 auction:
   bidding:
     lock-timeout-seconds: 30
+  items:
+    popular-limit: 15
   cors:
     allowed-origin: http://localhost:5173/


### PR DESCRIPTION
Allows the system to cap the number of popular items returned to the frontend.
- Added 'auction.items.popular-limit' property to application.yml (defaulting to 15).
- Implemented hard-capping logic in ItemService.findPopularItems to respect the limit while maintaining pagination support.
- Updated ItemServiceTest to verify capping behavior and handle manual instantiation.