### PR TITLE
feat: add startingBid to AuctionItemDTO

### DIFF
--- a/src/main/java/me/vrishab/auction/item/converter/ItemToAuctionItemDTO.java
+++ b/src/main/java/me/vrishab/auction/item/converter/ItemToAuctionItemDTO.java
@@ -23,6 +23,7 @@ public class ItemToAuctionItemDTO implements Converter<Item, AuctionItemDTO> {
                 source.getName(),
                 source.getDescription(),
                 source.getLocation(),
+                source.getInitialPrice(),
                 source.getCurrentBid(),
                 source.getImageUrls(),
                 userToUserSummaryDTOConverter.convert(source.getBuyer())

--- a/src/main/java/me/vrishab/auction/item/dto/AuctionItemDTO.java
+++ b/src/main/java/me/vrishab/auction/item/dto/AuctionItemDTO.java
@@ -20,6 +20,9 @@ public record AuctionItemDTO(
         @NonNull
         String location,
 
+        @NonNull
+        BigDecimal startingBid,
+
         BigDecimal currentBid,
 
         Set<String> imageUrls,


### PR DESCRIPTION
Includes the initial price as startingBid in the AuctionItemDTO to provide better context in the auction view.