### PR TITLE
fix: Cleanup bugs, deprecations, and code smells

### DIFF
--- a/src/main/java/me/vrishab/auction/auction/Auction.java
+++ b/src/main/java/me/vrishab/auction/auction/Auction.java
@@ -43,7 +43,7 @@ public class Auction {
             joinColumns = @JoinColumn(name = Constants.AUCTION_ID, unique = true),
             inverseJoinColumns = @JoinColumn(name = Constants.USER_ID)
     )
-    @Setter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE) // custom setUser() below maintains item.seller invariant
     private User user;
 
     public String getOwnerEmail() {

--- a/src/main/java/me/vrishab/auction/auction/AuctionService.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -37,6 +38,8 @@ public class AuctionService {
 
     private static final Logger logger = LoggerFactory.getLogger(AuctionService.class);
     private static final String BIDS_KEY_PREFIX = "auction:item:bids:";
+    private static final String REDIS_UNLOCK_SCRIPT =
+            "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
     private final AuctionRepository auctionRepo;
     private final UserRepository userRepo;
     private final ItemRepository itemRepo;
@@ -168,7 +171,7 @@ public class AuctionService {
                     public void afterCommit() {
                         String redisKey = BIDS_KEY_PREFIX + itemId;
                         // Use a scale to maintain precision for currency in double-based ZSet
-                        double score = bidAmount.setScale(4, BigDecimal.ROUND_HALF_UP).doubleValue();
+                        double score = bidAmount.setScale(4, RoundingMode.HALF_UP).doubleValue();
                         redisTemplate.opsForZSet().add(redisKey, userId, score);
 
                         // Publish bid update event for real-time feed
@@ -191,8 +194,7 @@ public class AuctionService {
             });
         } finally {
             // 4. Release Redis Lock
-            String luaScript = "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
-            redisTemplate.execute(new DefaultRedisScript<>(luaScript, Long.class),
+            redisTemplate.execute(new DefaultRedisScript<>(REDIS_UNLOCK_SCRIPT, Long.class),
                     Collections.singletonList(lockKey), lockId);
         }
     }
@@ -249,7 +251,7 @@ public class AuctionService {
 
     private void authorizedUser(UUID userUUID, Auction auction) {
         User user = userRepo.findById(userUUID)
-                .orElseThrow(() -> new ItemNotFoundByIdException(userUUID));
+                .orElseThrow(() -> new UserNotFoundByIdException(userUUID));
 
         if (!user.getEmail().equals(auction.getOwnerEmail())) {
             throw new UnauthorizedAuctionAccess(false);
@@ -258,7 +260,7 @@ public class AuctionService {
 
     private User getAndValidateBidder(UUID userUUID, Auction auction) {
         User user = userRepo.findById(userUUID)
-                .orElseThrow(() -> new ItemNotFoundByIdException(userUUID));
+                .orElseThrow(() -> new UserNotFoundByIdException(userUUID));
 
         if (user.getEmail().equals(auction.getOwnerEmail())) {
             throw new UnauthorizedAuctionAccess(true);

--- a/src/main/java/me/vrishab/auction/auction/dto/BidRequestDTO.java
+++ b/src/main/java/me/vrishab/auction/auction/dto/BidRequestDTO.java
@@ -1,13 +1,13 @@
 package me.vrishab.auction.auction.dto;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 
 public record BidRequestDTO(
         @NotNull(message = "bid amount is required")
-        @PositiveOrZero(message = "Please provide a valid price")
+        @Positive(message = "Please provide a valid price")
         BigDecimal bidAmount
 ) {
 }

--- a/src/main/java/me/vrishab/auction/system/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/me/vrishab/auction/system/exception/ExceptionHandlerAdvice.java
@@ -133,7 +133,7 @@ public class ExceptionHandlerAdvice {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public Result handleBadRequestBodyException(HttpMessageNotReadableException ex) {
-        return new Result(false, ex.getMessage().split(":")[0], ErrorCode.BAD_REQUEST);
+        return new Result(false, ex.getMessage().split(":", 2)[0], ErrorCode.BAD_REQUEST);
     }
 
     @ExceptionHandler({NoResourceFoundException.class, HttpRequestMethodNotSupportedException.class})

--- a/src/main/java/me/vrishab/auction/user/UserException.java
+++ b/src/main/java/me/vrishab/auction/user/UserException.java
@@ -18,7 +18,7 @@ public class UserException {
 
     public static class UserNotFoundByUsernameException extends ObjectNotFoundException {
         public UserNotFoundByUsernameException(String username) {
-            super("Could find user with username " + username);
+            super("Could not find user with username " + username);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,8 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
   redis:
-    host: localhost
-    port: 6379
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
 
 api:
   endpoint:

--- a/src/test/java/me/vrishab/auction/user/UserControllerTest.java
+++ b/src/test/java/me/vrishab/auction/user/UserControllerTest.java
@@ -86,7 +86,7 @@ class UserControllerTest {
         // When and Then
         this.mockMvc.perform(get(baseUrl + "/users/name3@domain.tld").accept(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.flag").value(false))
-                .andExpect(jsonPath("$.message").value("Could find user with username name3@domain.tld"))
+                .andExpect(jsonPath("$.message").value("Could not find user with username name3@domain.tld"))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
 

--- a/src/test/java/me/vrishab/auction/user/UserServiceTest.java
+++ b/src/test/java/me/vrishab/auction/user/UserServiceTest.java
@@ -85,7 +85,7 @@ class UserServiceTest {
         Throwable thrown = catchThrowable(() -> service.findByUsername("name1@domain.tld"));
 
         // Then
-        assertThat(thrown).isInstanceOf(UserNotFoundByUsernameException.class).hasMessage("Could find user with username name1@domain.tld");
+        assertThat(thrown).isInstanceOf(UserNotFoundByUsernameException.class).hasMessage("Could not find user with username name1@domain.tld");
 
         verify(repository, times(1)).findByEmail("name1@domain.tld");
     }


### PR DESCRIPTION
- Throw UserNotFoundByIdException (not ItemNotFoundByIdException) when user lookup fails in authorizedUser() and getAndValidateBidder()
- Fix typo in UserNotFoundByUsernameException message (missing 'not')
- Replace deprecated BigDecimal.ROUND_HALF_UP with RoundingMode.HALF_UP
- Tighten BidRequestDTO bid amount constraint from @PositiveOrZero to @Positive
- Externalize Redis host/port via REDIS_HOST/REDIS_PORT env vars with localhost:6379 defaults
- Use split with limit 2 in ExceptionHandlerAdvice to avoid potential ArrayIndexOutOfBoundsException
- Extract Redis Lua unlock script to REDIS_UNLOCK_SCRIPT constant
- Add clarifying comment on Auction.user @Setter(AccessLevel.NONE)