### PR TITLE
refactor: derive Item.seller from auction.user instead of storing it

### DIFF
--- a/src/main/java/me/vrishab/auction/auction/Auction.java
+++ b/src/main/java/me/vrishab/auction/auction/Auction.java
@@ -43,7 +43,7 @@ public class Auction {
             joinColumns = @JoinColumn(name = Constants.AUCTION_ID, unique = true),
             inverseJoinColumns = @JoinColumn(name = Constants.USER_ID)
     )
-    @Setter(AccessLevel.NONE) // custom setUser() below maintains item.seller invariant
+    @Setter(AccessLevel.NONE)
     private User user;
 
     public String getOwnerEmail() {
@@ -57,10 +57,7 @@ public class Auction {
 
     public void addAllItems(Set<Item> items) {
         this.items.addAll(items);
-        this.items.forEach(item -> {
-            item.setAuction(this);
-            if (user != null) item.setSeller(user.getEmail());
-        });
+        this.items.forEach(item -> item.setAuction(this));
     }
 
     public Set<Item> getItems() {
@@ -69,6 +66,5 @@ public class Auction {
 
     public void setUser(User user) {
         this.user = user;
-        this.items.forEach(item -> item.setSeller(this.user.getEmail()));
     }
 }

--- a/src/main/java/me/vrishab/auction/item/Item.java
+++ b/src/main/java/me/vrishab/auction/item/Item.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.UUID;
 
 @Entity
-@Table(indexes = @Index(columnList = "seller"))
 @Setter
 @Getter
 @NoArgsConstructor(access = AccessLevel.PUBLIC, force = true)
@@ -59,9 +58,6 @@ public class Item {
     @Setter(AccessLevel.NONE)
     private Set<User> likedBy = new HashSet<>();
 
-    @Column(nullable = false)
-    private String seller;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinTable(
             name = Constants.ITEM_BUYER_TBL,
@@ -72,6 +68,10 @@ public class Item {
 
     @Version
     private Long version = 0L;
+
+    public String getSeller() {
+        return auction.getUser().getEmail();
+    }
 
     public String getBuyerEmail() {
         if (buyer == null) return null;

--- a/src/test/java/me/vrishab/auction/TestData.java
+++ b/src/test/java/me/vrishab/auction/TestData.java
@@ -24,7 +24,6 @@ public class TestData {
             item.setDescription("Description " + i);
             item.setLocation(i % 3 == 1 ? "MA" : "CA");
             item.setLegitimacyProof("Proof");
-            item.setSeller(seller.getEmail());
             item.setBuyer(buyer);
 
             items.add(item);

--- a/src/test/java/me/vrishab/auction/auction/AuctionServiceTest.java
+++ b/src/test/java/me/vrishab/auction/auction/AuctionServiceTest.java
@@ -258,7 +258,6 @@ class AuctionServiceTest {
         oldItem.setImageUrls(Set.of("<images>"));
         oldItem.setLegitimacyProof("Proof");
         oldItem.setInitialPrice(BigDecimal.valueOf(100.00));
-        oldItem.setSeller("name0@domain.tld");
 
         Auction oldAuction = new Auction();
 
@@ -344,7 +343,6 @@ class AuctionServiceTest {
         oldItem.setLocation("MA");
         oldItem.setImageUrls(Set.of("<images>"));
         oldItem.setLegitimacyProof("Proof");
-        oldItem.setSeller("name0@domain.tld");
         oldItem.setInitialPrice(BigDecimal.valueOf(100.00));
 
         Auction oldAuction = new Auction();
@@ -418,7 +416,6 @@ class AuctionServiceTest {
         oldItem.setImageUrls(Set.of("<images>"));
         oldItem.setLegitimacyProof("Proof");
         oldItem.setInitialPrice(BigDecimal.valueOf(100.00));
-        oldItem.setSeller("name0@domain.tld");
 
         Auction oldAuction = new Auction();
 
@@ -472,7 +469,6 @@ class AuctionServiceTest {
         otherItem.setImageUrls(Set.of("<images>"));
         otherItem.setExtras(null);
         otherItem.setLegitimacyProof("Proof");
-        otherItem.setSeller(otherUser.getEmail());
         given(itemRepo.findById(UUID.fromString("e2b2dd83-0e5d-4d73-b5cc-744f3fdc49a2"))).willReturn(Optional.of(otherItem));
 
         // When
@@ -501,7 +497,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 
@@ -549,7 +544,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 
@@ -597,7 +591,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 
@@ -660,7 +653,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 
@@ -715,7 +707,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 
@@ -770,7 +761,6 @@ class AuctionServiceTest {
         item.setImageUrls(Set.of("<images>"));
         item.setLegitimacyProof("Proof");
         item.setInitialPrice(BigDecimal.valueOf(100.00));
-        item.setSeller("name0@domain.tld");
 
         Auction auction = new Auction();
 

--- a/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
+++ b/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
@@ -92,7 +92,6 @@ public class DashboardFeaturesIntegrationTest {
         item1.setDescription("Description");
         item1.setLocation("Boston");
         item1.setInitialPrice(BigDecimal.valueOf(100));
-        item1.setSeller(testUser.getEmail());
         item1.setAuction(activeAuction);
         item1 = itemRepository.save(item1);
 
@@ -104,7 +103,6 @@ public class DashboardFeaturesIntegrationTest {
         item2.setDescription("Description");
         item2.setLocation("New York");
         item2.setInitialPrice(BigDecimal.valueOf(50));
-        item2.setSeller(testUser.getEmail());
         item2.setAuction(activeAuction);
         itemRepository.save(item2);
     }

--- a/src/test/java/me/vrishab/auction/item/ItemServiceTest.java
+++ b/src/test/java/me/vrishab/auction/item/ItemServiceTest.java
@@ -71,8 +71,7 @@ class ItemServiceTest {
                 () -> assertThat(returnedItem.getLocation()).isEqualTo("CA"),
                 () -> assertThat(returnedItem.getImageUrls()).isEqualTo(Set.of("<images>")),
                 () -> assertThat(returnedItem.getExtras()).isEqualTo(null),
-                () -> assertThat(returnedItem.getLegitimacyProof()).isEqualTo("Proof"),
-                () -> assertThat(returnedItem.getSeller()).isEqualTo("name@domain.tld")
+                () -> assertThat(returnedItem.getLegitimacyProof()).isEqualTo("Proof")
         );
 
 


### PR DESCRIPTION
Removed the denormalized `seller` String field from Item, which required manual synchronization with auction.user on every write. Seller is now derived via getSeller() -> auction.getUser().getEmail(), eliminating the sync logic in Auction.addAllItems() and Auction.setUser().