### PR TITLE
refactor: replace @JoinTable with @JoinColumn for ManyToOne FKs

### DIFF
--- a/src/main/java/me/vrishab/auction/auction/Auction.java
+++ b/src/main/java/me/vrishab/auction/auction/Auction.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import me.vrishab.auction.item.Item;
 import me.vrishab.auction.user.model.User;
-import me.vrishab.auction.utils.Constants;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -38,11 +37,7 @@ public class Auction {
     private Set<Item> items = new HashSet<>();
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
-    @JoinTable(
-            name = Constants.USER_AUCTION_TBL,
-            joinColumns = @JoinColumn(name = Constants.AUCTION_ID, unique = true),
-            inverseJoinColumns = @JoinColumn(name = Constants.USER_ID)
-    )
+    @JoinColumn(name = "user_id", nullable = false)
     @Setter(AccessLevel.NONE)
     private User user;
 

--- a/src/main/java/me/vrishab/auction/item/Item.java
+++ b/src/main/java/me/vrishab/auction/item/Item.java
@@ -59,11 +59,7 @@ public class Item {
     private Set<User> likedBy = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = Constants.ITEM_BUYER_TBL,
-            joinColumns = @JoinColumn(name = Constants.ITEM_ID),
-            inverseJoinColumns = @JoinColumn(nullable = false)
-    )
+    @JoinColumn(name = "buyer_id")
     private User buyer;
 
     @Version

--- a/src/main/java/me/vrishab/auction/utils/Constants.java
+++ b/src/main/java/me/vrishab/auction/utils/Constants.java
@@ -8,7 +8,5 @@ public class Constants {
     public final static String IMAGE_URL = "IMAGE_URL";
     public final static String WISHLIST_TBL = "WISHLIST";
     public final static String USER_ID = "USER_ID";
-    public final static String ITEM_BUYER_TBL = "ITEM_BUYER";
-    public final static String USER_AUCTION_TBL = "USER_AUCTION";
 
 }


### PR DESCRIPTION
USER_AUCTION and ITEM_BUYER were join tables used for simple ManyToOne relationships (auction→user, item→buyer). Replaced both with direct FK columns (user_id on auction, buyer_id on item), eliminating two unnecessary tables and joins. Removed the now-unused constants.