### PR TITLE
feat: add AuctionStatus enum and replace active param with status filter

### DIFF
--- a/src/main/java/me/vrishab/auction/auction/Auction.java
+++ b/src/main/java/me/vrishab/auction/auction/Auction.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+
 @Entity
 @Setter
 @Getter
@@ -40,6 +41,13 @@ public class Auction {
     @JoinColumn(name = "user_id", nullable = false)
     @Setter(AccessLevel.NONE)
     private User user;
+
+    public AuctionStatus getStatus() {
+        Instant now = Instant.now();
+        if (now.isBefore(startTime)) return AuctionStatus.SCHEDULED;
+        if (now.isAfter(endTime)) return AuctionStatus.ENDED;
+        return AuctionStatus.ACTIVE;
+    }
 
     public String getOwnerEmail() {
         return user.getEmail();

--- a/src/main/java/me/vrishab/auction/auction/AuctionController.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionController.java
@@ -68,8 +68,8 @@ public class AuctionController {
     public Result findAllAuctions(
             @ModelAttribute
             @Valid PageRequestParams pageParams,
-            @RequestParam(required = false) Boolean active) {
-        Page<Auction> auctionPage = this.auctionService.findAll(pageParams, active);
+            @RequestParam(required = false) AuctionStatus status) {
+        Page<Auction> auctionPage = this.auctionService.findAll(pageParams, status);
 
         List<AuctionDTO> dtos = auctionPage.getContent().stream().map(
                         this.auctionToAuctionDTOConverter::convert

--- a/src/main/java/me/vrishab/auction/auction/AuctionService.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionService.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.*;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -77,17 +77,18 @@ public class AuctionService {
     }
 
     @Transactional(readOnly = true)
-    public Page<Auction> findAll(PageRequestParams pageSettings, Boolean active) {
+    public Page<Auction> findAll(PageRequestParams pageSettings, AuctionStatus status) {
         Pageable pageable = Pageable.unpaged();
         if (pageSettings != null && pageSettings.isValid())
             pageable = pageSettings.createPageRequest();
 
-        if (active != null) {
-            if (active) {
-                return this.auctionRepo.findAll(AuctionSpecification.isActive(), pageable);
-            } else {
-                return this.auctionRepo.findAll(AuctionSpecification.isInactive(), pageable);
-            }
+        if (status != null) {
+            Specification<Auction> spec = switch (status) {
+                case ACTIVE -> AuctionSpecification.isActive();
+                case SCHEDULED -> AuctionSpecification.isScheduled();
+                case ENDED -> AuctionSpecification.isEnded();
+            };
+            return this.auctionRepo.findAll(spec, pageable);
         }
 
         return this.auctionRepo.findAll(pageable);
@@ -222,11 +223,7 @@ public class AuctionService {
     }
 
     private void checkAuctionInBidingPhase(Auction auction) {
-        Instant now = Instant.now();
-        boolean isAuctionStarted = auction.getStartTime().isBefore(now);
-        boolean isAuctionEnded = auction.getEndTime().isBefore(now);
-
-        if (!isAuctionStarted || isAuctionEnded) {
+        if (auction.getStatus() != AuctionStatus.ACTIVE) {
             throw new AuctionForbiddenBidingPhaseException(auction.getId());
         }
     }
@@ -278,7 +275,7 @@ public class AuctionService {
     }
 
     private void checkAuctionNotStarted(Auction auction) {
-        if (auction.getStartTime().isBefore(Instant.now())) {
+        if (auction.getStatus() != AuctionStatus.SCHEDULED) {
             throw new AuctionForbiddenUpdateException(auction.getId());
         }
     }

--- a/src/main/java/me/vrishab/auction/auction/AuctionSpecification.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionSpecification.java
@@ -16,14 +16,14 @@ public class AuctionSpecification {
         };
     }
 
-    public static Specification<Auction> isInactive() {
-        return (root, query, criteriaBuilder) -> {
-            Instant now = Instant.now();
-            return criteriaBuilder.or(
-                    criteriaBuilder.greaterThan(root.get("startTime"), now),
-                    criteriaBuilder.lessThan(root.get("endTime"), now)
-            );
-        };
+    public static Specification<Auction> isScheduled() {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.greaterThan(root.get("startTime"), Instant.now());
+    }
+
+    public static Specification<Auction> isEnded() {
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.lessThan(root.get("endTime"), Instant.now());
     }
 
 }

--- a/src/main/java/me/vrishab/auction/auction/AuctionStatus.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionStatus.java
@@ -1,0 +1,7 @@
+package me.vrishab.auction.auction;
+
+public enum AuctionStatus {
+    SCHEDULED,
+    ACTIVE,
+    ENDED
+}

--- a/src/main/java/me/vrishab/auction/auction/converter/AuctionToAuctionDTOConverter.java
+++ b/src/main/java/me/vrishab/auction/auction/converter/AuctionToAuctionDTOConverter.java
@@ -33,6 +33,7 @@ public class AuctionToAuctionDTOConverter implements Converter<Auction, AuctionD
                 source.getName(),
                 source.getStartTime(),
                 source.getEndTime(),
+                source.getStatus(),
                 itemDTOs,
                 userToUserSummaryDTOConverter.convert(source.getUser())
         );

--- a/src/main/java/me/vrishab/auction/auction/dto/AuctionDTO.java
+++ b/src/main/java/me/vrishab/auction/auction/dto/AuctionDTO.java
@@ -1,6 +1,7 @@
 package me.vrishab.auction.auction.dto;
 
 import lombok.NonNull;
+import me.vrishab.auction.auction.AuctionStatus;
 import me.vrishab.auction.item.dto.AuctionItemDTO;
 import me.vrishab.auction.user.dto.UserSummaryDTO;
 
@@ -20,6 +21,9 @@ public record AuctionDTO(
 
         @NonNull
         Instant endTime,
+
+        @NonNull
+        AuctionStatus status,
 
         @NonNull
         List<AuctionItemDTO> items,

--- a/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
+++ b/src/test/java/me/vrishab/auction/auction/DashboardFeaturesIntegrationTest.java
@@ -119,21 +119,30 @@ public class DashboardFeaturesIntegrationTest {
 
         // Find active only
         mockMvc.perform(get(baseUrl + "/auctions")
-                        .param("active", "true")
+                        .param("status", "ACTIVE")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(true))
                 .andExpect(jsonPath("$.data.content", hasSize(1)))
                 .andExpect(jsonPath("$.data.content[0].name").value("Active Auction"));
 
-        // Find inactive only
+        // Find scheduled only
         mockMvc.perform(get(baseUrl + "/auctions")
-                        .param("active", "false")
+                        .param("status", "SCHEDULED")
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.flag").value(true))
-                .andExpect(jsonPath("$.data.content", hasSize(2)))
-                .andExpect(jsonPath("$.data.content[*].name", containsInAnyOrder("Future Auction", "Past Auction")));
+                .andExpect(jsonPath("$.data.content", hasSize(1)))
+                .andExpect(jsonPath("$.data.content[0].name").value("Future Auction"));
+
+        // Find ended only
+        mockMvc.perform(get(baseUrl + "/auctions")
+                        .param("status", "ENDED")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.flag").value(true))
+                .andExpect(jsonPath("$.data.content", hasSize(1)))
+                .andExpect(jsonPath("$.data.content[0].name").value("Past Auction"));
     }
 
     @Test


### PR DESCRIPTION
- Add AuctionStatus enum (SCHEDULED, ACTIVE, ENDED)
- Derive status from startTime/endTime via Auction.getStatus()
- Expose status field in AuctionDTO
- Replace duplicated Instant.now() phase checks in AuctionService with getStatus()
- Replace GET /auctions?active=true/false with ?status=ACTIVE/SCHEDULED/ENDED
- Split AuctionSpecification.isInactive() into isScheduled() and isEnded()