### PR TITLE
chore: disable OSIV, expand EntityGraphs, fix inheritance mapping, clean config

### DIFF
--- a/src/main/java/me/vrishab/auction/AuctionApplication.java
+++ b/src/main/java/me/vrishab/auction/AuctionApplication.java
@@ -3,9 +3,10 @@ package me.vrishab.auction;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = RedisRepositoriesAutoConfiguration.class)
 @EnableScheduling
 public class AuctionApplication {
 

--- a/src/main/java/me/vrishab/auction/auction/AuctionRepository.java
+++ b/src/main/java/me/vrishab/auction/auction/AuctionRepository.java
@@ -16,21 +16,21 @@ import java.util.UUID;
 
 @Repository
 public interface AuctionRepository extends JpaRepository<Auction, UUID>, JpaSpecificationExecutor<Auction> {
-    @EntityGraph(attributePaths = {"user"})
+    @EntityGraph(attributePaths = {"user", "items", "items.buyer", "items.imageUrls"})
     List<Auction> findByUser(User user);
 
     @Override
-    @EntityGraph(attributePaths = {"user"})
+    @EntityGraph(attributePaths = {"user", "items", "items.buyer", "items.imageUrls"})
     Optional<Auction> findById(UUID id);
 
     void deleteByUser(User user);
 
     @Override
-    @EntityGraph(attributePaths = {"user"})
+    @EntityGraph(attributePaths = {"user", "items", "items.buyer", "items.imageUrls"})
     Page<Auction> findAll(Pageable pageable);
 
     @Override
-    @EntityGraph(attributePaths = {"user"})
+    @EntityGraph(attributePaths = {"user", "items", "items.buyer", "items.imageUrls"})
     @NonNull
     Page<Auction> findAll(@NonNull Specification<Auction> spec, @NonNull Pageable pageable);
 }

--- a/src/main/java/me/vrishab/auction/item/Item.java
+++ b/src/main/java/me/vrishab/auction/item/Item.java
@@ -30,7 +30,7 @@ public class Item {
 
     private String location;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
             name = Constants.IMAGE_TBL,
             joinColumns = @JoinColumn(name = Constants.ITEM_ID, nullable = false)

--- a/src/main/java/me/vrishab/auction/item/ItemRepository.java
+++ b/src/main/java/me/vrishab/auction/item/ItemRepository.java
@@ -16,11 +16,11 @@ import java.util.UUID;
 public interface ItemRepository extends JpaRepository<Item, UUID>, JpaSpecificationExecutor<Item> {
 
     @Override
-    @EntityGraph(attributePaths = {"buyer", "auction.user"})
+    @EntityGraph(attributePaths = {"buyer", "auction.user", "imageUrls"})
     Optional<Item> findById(UUID id);
 
     @Override
-    @EntityGraph(attributePaths = {"buyer", "auction.user"})
+    @EntityGraph(attributePaths = {"buyer", "auction.user", "imageUrls"})
     Page<Item> findAll(@Nullable Specification<Item> spec, Pageable pageable);
 
 }

--- a/src/main/java/me/vrishab/auction/user/model/BankAccount.java
+++ b/src/main/java/me/vrishab/auction/user/model/BankAccount.java
@@ -2,7 +2,6 @@ package me.vrishab.auction.user.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -13,7 +12,6 @@ import lombok.Setter;
 import java.math.BigDecimal;
 
 @Entity
-@PrimaryKeyJoinColumn(name = "BANKACCOUNT_ID")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PUBLIC, force = true)

--- a/src/main/java/me/vrishab/auction/user/model/CreditCard.java
+++ b/src/main/java/me/vrishab/auction/user/model/CreditCard.java
@@ -2,7 +2,6 @@ package me.vrishab.auction.user.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -14,7 +13,6 @@ import org.hibernate.validator.constraints.CreditCardNumber;
 import java.math.BigDecimal;
 
 @Entity
-@PrimaryKeyJoinColumn(name = "CREDITCARD_ID")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PUBLIC, force = true)

--- a/src/main/java/me/vrishab/auction/wishlist/WishlistRepository.java
+++ b/src/main/java/me/vrishab/auction/wishlist/WishlistRepository.java
@@ -28,6 +28,7 @@ public interface WishlistRepository extends JpaRepository<Wishlist, UUID> {
             "LEFT JOIN FETCH i.buyer " +
             "LEFT JOIN FETCH i.auction a " +
             "LEFT JOIN FETCH a.user " +
+            "LEFT JOIN FETCH i.imageUrls " +
             "WHERE w.user = :user")
     List<Item> findItemsByUser(@Param("user") User user);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,11 +7,11 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100
   redis:
     host: ${REDIS_HOST:localhost}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       enabled: true
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: create-drop
 


### PR DESCRIPTION


- Disable spring.jpa.open-in-view in main + test yml so lazy associations outside @Transactional fail loudly instead of silently lazy-loading through the OSIV session during view rendering.
- Make Item.imageUrls @ElementCollection EAGER as a defensive default; add "imageUrls" / "items.imageUrls" to every @EntityGraph that fetches Items (FETCH-mode @EntityGraph overrides field-level EAGER, so explicit inclusion is required).
- Expand AuctionRepository @EntityGraph from {"user"} to {"user", "items", "items.buyer", "items.imageUrls"} on findById, findAll(Pageable), findAll(Specification, Pageable), and findByUser since AuctionDTO embeds AuctionItemDTO which serializes buyer + imageUrls.
- Add LEFT JOIN FETCH i.imageUrls to WishlistRepository.findItemsByUser.
- Remove @PrimaryKeyJoinColumn from BankAccount and CreditCard. They were silently ignored by Hibernate (HHH000137) because BillingDetails uses InheritanceType.TABLE_PER_CLASS, not JOINED.
- Drop redundant explicit hibernate dialect (auto-detected from JDBC URL).
- Exclude RedisRepositoriesAutoConfiguration to silence the 8 "Could not safely identify store assignment" warnings from the strict-mode scan; RedisAutoConfiguration is preserved so RedisTemplate keeps working.