### PR TITLE
fix: move redis config under spring.data.redis for Spring Boot 3.x

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,9 +13,11 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 100
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
 
 api:
   endpoint:


### PR DESCRIPTION
The spring.redis.* property namespace was removed in Spring Boot 3.0; the auto-configured LettuceConnectionFactory only reads spring.data.redis.*. Without this rename the host/port/password overrides were silently dropped and Lettuce fell back to its built-in localhost:6379 defaults, ignoring the external REDIS_HOST env var.

Also add a password property with an empty default so a missing REDIS_PASSWORD doesn't fail property resolution in local dev.